### PR TITLE
Add initial support for fcntl and flock virtualization

### DIFF
--- a/test_modules/mountreal.c
+++ b/test_modules/mountreal.c
@@ -35,9 +35,7 @@ VU_PROTOTYPES(mountreal)
 
 	struct vu_module_t vu_module = {
 		.name = "mountreal",
-		.description = "Mount mapping to FS (server side)",
-		.mod_nr_vsyscalls = 0,
-		.vsyscalls = NULL
+		.description = "Mount mapping to FS (server side)"
 	};
 
 struct mountreal_entry {

--- a/test_modules/netlinkdump.c
+++ b/test_modules/netlinkdump.c
@@ -35,9 +35,7 @@ VU_PROTOTYPES(netlinkdump)
 
 	struct vu_module_t vu_module = {
 		.name = "netlinkdump",
-		.description = "dump netlink messages",
-		.mod_nr_vsyscalls = 0,
-		.vsyscalls = NULL
+		.description = "dump netlink messages"
 	};
 
 static struct vuht_entry_t *ht;

--- a/test_modules/unreal.c
+++ b/test_modules/unreal.c
@@ -58,9 +58,7 @@ VU_PROTOTYPES(unreal)
 
 	struct vu_module_t vu_module = {
 		.name = "unreal",
-		.description = "Mapping to FS (server side)",
-		.mod_nr_vsyscalls = 0,
-		.vsyscalls = NULL
+		.description = "Mapping to FS (server side)"
 	};
 
 int vu_unreal_getdents64(unsigned int fd, struct dirent64 *dirp, unsigned int count, void *private) {

--- a/test_modules/unrealcap.c
+++ b/test_modules/unrealcap.c
@@ -41,9 +41,7 @@ VU_PROTOTYPES(unrealcap)
 
 	struct vu_module_t vu_module = {
 		.name = "unrealcap",
-		.description = "virtualize capabilities",
-		.mod_nr_vsyscalls = 0,
-		.vsyscalls = NULL
+		.description = "virtualize capabilities"
 	};
 
 struct vu_cap_t {

--- a/test_modules/unrealinfofs.c
+++ b/test_modules/unrealinfofs.c
@@ -61,9 +61,7 @@ VU_PROTOTYPES(unrealinfofs)
 
 	struct vu_module_t vu_module = {
 		.name = "unrealinfofs",
-		.description = "example of informational file system",
-		.mod_nr_vsyscalls = 0,
-		.vsyscalls = NULL
+		.description = "example of informational file system"
 	};
 
 struct info {

--- a/test_modules/unrealsock.c
+++ b/test_modules/unrealsock.c
@@ -35,9 +35,7 @@ VU_PROTOTYPES(unrealsock)
 
 	struct vu_module_t vu_module = {
 		.name = "unrealsock",
-		.description = "tcp-ip stack server side",
-		.mod_nr_vsyscalls = 0,
-		.vsyscalls = NULL
+		.description = "tcp-ip stack server side"
 	};
 
 static struct vuht_entry_t *ht[3];

--- a/test_modules/unrealuidgid.c
+++ b/test_modules/unrealuidgid.c
@@ -34,9 +34,7 @@ VU_PROTOTYPES(unrealuidgid)
 
 	struct vu_module_t vu_module = {
 		.name = "unrealuidgid",
-		.description = "virtualize uid gid",
-		.mod_nr_vsyscalls = 0,
-		.vsyscalls = NULL
+		.description = "virtualize uid gid"
 	};
 
 struct vu_uid_gid_t {

--- a/umvu/include/service.h
+++ b/umvu/include/service.h
@@ -61,17 +61,5 @@ __attribute__((always_inline))
 		return service->module_syscall[vu_syscall_number];
 	}
 
-__attribute__((always_inline))
-	static inline syscall_t service_vsyscall(struct vuht_entry_t *ht, int vu_syscall_number) {
-		struct vu_service_t *service = vuht_get_service(ht);
-		if (service->mod->vsyscalls != NULL && vu_syscall_number < service->mod->mod_nr_vsyscalls)
-			return service->module_syscall[VU_NR_MODULE_SYSCALLS + vu_syscall_number];
-		
-		/*
-		 * if the module doesn't declare any new sc,
-		 * the element at VU_NR_MODULE_SYSCALLS is always sys_enosys */
-		return service->module_syscall[VU_NR_MODULE_SYSCALLS];
-	}
-
 #endif
 

--- a/umvu/src/vu_modutils.c
+++ b/umvu/src/vu_modutils.c
@@ -148,28 +148,6 @@ struct vu_service_t *module_load(const char *modname)
 			}
 		}
 
-		/*
-		 * note that even if the module doesn't export any new sc, one is added
-		 * anyway at the end of the array
-		 * */
-		if (module->mod_nr_vsyscalls == 0) {
-			service->module_syscall[i] = sys_enosys;
-			return service;
-		}
-
-		// load new syscalls added by the module
-		for (; i < VU_NR_MODULE_SYSCALLS + VSYSCALL_NR; i++) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-			service->module_syscall[i] = dlsym(handle, module->vsyscalls[i - VU_NR_MODULE_SYSCALLS]);
-#pragma GCC diagnostic pop
-			if (service->module_syscall[i] == NULL) {
-				service->module_syscall[i] = sys_enosys;
-			} else {
-				printkdebug(m, "%s %s module vsyscall added", module->name, module->vsyscalls[i - VU_NR_MODULE_SYSCALLS]);
-			}
-		}
-
 		return service;
 	} else {
 		errno = EINVAL;

--- a/umvu/src/vu_wrap_file.c
+++ b/umvu/src/vu_wrap_file.c
@@ -569,48 +569,18 @@ void wi_fcntl(struct vuht_entry_t *ht, struct syscall_descriptor_t *sd) {
 				 * using the real SC
 				 * */
 				printkdebug(F, "wi_fcntl for file locking: %d", cmd);
+				printkdebug(F, "the path of the file is %s", sd->extra->path);
+
 				/*
 				 * let VUFS manage this since it can create virtual representations
 				 * of the fs and apply locks on them
 				 * */
-
-				// define the struct here to allow access to its fields
-				struct vufs_t {
-					pthread_mutex_t mutex;
-
-					char *source;
-					char *target;
-					int rdirfd;
-					int vdirfd;
-					int ddirfd;
-					int flags;
-
-					char *except[];
-				};
-
-				struct vufs_t *vufs = vu_get_ht_private_data();
-				char *path = sd->extra->path + 1;
-
-				printkdebug(F, "virtual hierarchy root fd: %d", vufs->vdirfd);
-				printkdebug(F, "the path of the file is /%s", sd->extra->path);
-
-				// call the VUFS-added sc to copy the file in the virtual hierarchy
-				size_t MAX_SIZE = ((1ULL<<((sizeof(size_t)*8)-1))-1);
-				int res = service_vsyscall(ht, 0)(vufs, path, MAX_SIZE);
-				if (res < 0) {
-					// copyfile didn't work, try to execute the sc on the original file anyway
-					printkdebug(F, "Could not create virtual copy of %s", sd->extra->path);
+				struct flock *lockinfo = (struct flock*) sd->syscall_args[2];
+				ret_value = service_syscall(ht, __VU_fcntl)(sfd, cmd, lockinfo, sd->extra->path);
+				if (ret_value < 0) {
+					sd->ret_value = -errno;
 				} else {
-					int flags = vu_fd_get_fdflags(fd, sd->extra->nested);
-					int vfd = openat(vufs->vdirfd, path, flags | O_CREAT, 0600);
-					//int vfd = openat(vufs->vdirfd, path+1, flags);
-
-					if (vfd < 0) {
-						// cannot open file, go on anyway
-						printkdebug(F, "Could not open virtual copy of file %s", sd->extra->path);
-					} else {
-						sd->syscall_args[0] = vfd;
-					}
+					sd->ret_value = ret_value;
 				}
 
 				return;

--- a/umvu/src/vu_wrap_file.c
+++ b/umvu/src/vu_wrap_file.c
@@ -629,12 +629,7 @@ void wi_fcntl(struct vuht_entry_t *ht, struct syscall_descriptor_t *sd) {
 			case F_OFD_SETLK:
 			case F_OFD_SETLKW:
 				/*
-				 * File locking commands
-				 * if the file is not virtualized, execute the real SC
-				 * then check for the return value in the wrapoutf function
-				 * */
-				/*
-				 * Actually without VUFS we can't do much, so we let the
+				 * without VUFS we can't do much, so we let the
 				 * SC run unmodified and fail if it has to
 				 * */
 				return;
@@ -702,60 +697,33 @@ void wo_fcntl(struct vuht_entry_t *ht, struct syscall_descriptor_t *sd) {
 					vu_fd_set_flflags(fd, nested, flags);
 			}
 			break;
-		case F_GETLK:
-		case F_SETLK:
-		case F_SETLKW:
-		case F_OFD_GETLK:
-		case F_OFD_SETLK:
-		case F_OFD_SETLKW:
-			/*
-			 * Actually this shouldn't be needed since we call the VUFS
-			 * fcntl implementations directly in the wrapin function
-			 * (and the action should be SKIPIT [?])
-			 * */
-			printkdebug(F, "wo_fcntl for file locking: %d", cmd);
-			printkdebug(F, "fcntl orig_ret_value: %d", ret_value);
-			printkdebug(F, "orig_rax value: %d", sd->syscall_number);
-			if (ret_value < 0) {
-				// check errno to know the type of the error
-				// |_ how to get errno value??
-				printkdebug(F, "real fcntl call failed");
-			}
-			break;
 	}
+
 	sd->ret_value = ret_value;
 }
 
-/*
- * The following two wrapper functions should behave (almost) as the
- * fcntl ones since their goal is very similar
- * */
 void wi_flock(struct vuht_entry_t *ht, struct syscall_descriptor_t *sd) {
 	int fd = sd->syscall_args[0];
 	int op = sd->syscall_args[1];
-	printkdebug(F, "wi_flock on fd %d: %d", fd, op);
+	int ret_value;
+
 	if (ht) {
-		// handle lock on virtualized file
+		printkdebug(F, "wi_flock for file locking: %d", op);
+		printkdebug(F, "the path of the file is %s", sd->extra->path);
+
+		ret_value = service_syscall(ht, __VU_flock)(fd, op, sd->extra->path);
+		if (ret_value < 0) {
+			sd->ret_value = -errno;
+		} else {
+			sd->ret_value = ret_value;
+		}
+
+		sd->ret_value = ret_value;
+		sd->action = SKIPIT;
+		return;
 	} 
 
-	// always virtualize
-}
-
-void wo_flock(struct vuht_entry_t *ht, struct syscall_descriptor_t *sd) {
-	// do not check for the ht variable: assume this function
-	// runs only if the file isn't virtualized
-	int fd = sd->syscall_args[0];
-	int op = sd->syscall_args[1];
-	int ret_value = sd->orig_ret_value;
-	printkdebug(F, "wo_flock on fd %d: %d", fd, op);
-	printkdebug(F, "flock orig_ret_value: %d", ret_value);
-
-	if (ret_value < 0) {
-		// check errno as in wo_fcntl
-		printkdebug(F, "real flock call failed");
-	}
-
-	sd->ret_value = ret_value;
+	sd->action = DOIT;
 }
 
 /* umask */

--- a/vu_syscalls.conf
+++ b/vu_syscalls.conf
@@ -71,7 +71,7 @@ capset/2: sc, capset, NULL, NULL
 clock_gettime/2, gettimeofday/2, time/1: sc, clock_gettime, NULL, NULL
 clock_settime/2, settimeofday/2: sc, clock_settime, NULL, NULL
 clock_getres/2: sc, clock_getres, NULL, NULL
-flock/3: std, flock, NULL, flock
+flock/3: std, flock, NULL, NULL
 
 BUILTIN
 execve/13, execveat/315: path, execve, NULL, execve

--- a/vubinfmt/vubinfmt.c
+++ b/vubinfmt/vubinfmt.c
@@ -33,9 +33,7 @@ VU_PROTOTYPES(vubinfmt)
 
 	struct vu_module_t vu_module = {
 		.name = "vubinfmt",
-		.description = "vu binfmt_misc support",
-		.mod_nr_vsyscalls = 0,
-		.vsyscalls = NULL
+		.description = "vu binfmt_misc support"
 	};
 
 struct vubinfmt_entry_t {

--- a/vudev/vudev.c
+++ b/vudev/vudev.c
@@ -37,9 +37,7 @@ VU_PROTOTYPES(vudev)
 
 	struct vu_module_t vu_module = {
 		.name = "vudev",
-		.description = "vu virtual devices",
-		.mod_nr_vsyscalls = 0,
-		.vsyscalls = NULL
+		.description = "vu virtual devices"
 	};
 
 #define VUDEVFLAGS_DEVID 1

--- a/vufs/vufs.c
+++ b/vufs/vufs.c
@@ -231,9 +231,7 @@ char *vsyscalls[] = { [0] = "vufs_copyfile" };
 
 struct vu_module_t vu_module = {
 	.name = "vufs",
-	.description = "vu filesystem patchworking",
-	.mod_nr_vsyscalls = 1,
-	.vsyscalls = vsyscalls
+	.description = "vu filesystem patchworking"
 };
 
 __attribute__((constructor))

--- a/vufs/vufs.c
+++ b/vufs/vufs.c
@@ -217,7 +217,8 @@ void *vu_vufs_init(void) {
 	vu_syscall_handler(s, lseek) = lseek;
 	vu_syscall_handler(s, pread64) = pread;
 	vu_syscall_handler(s, pwrite64) = pwrite;
-	vu_syscall_handler(s, fcntl) = fcntl;
+
+	/* removed fcntl line since it is virtualized */
 
 #pragma GCC diagnostic pop
 	return NULL;

--- a/vufs/vufsops.c
+++ b/vufs/vufsops.c
@@ -754,11 +754,7 @@ int vu_vufs_fcntl(int fd, int cmd, ...) {
 			struct flock *lockinfo = va_arg(ap, struct flock*);
 			char *dest_path = va_arg(ap, char *);
 			
-			/* 
-			 * get the original path from the fd table
-			 * then make a copy in the virtual hierarchy
-			 * */
-			//vu_fd_get_path(fd, 0, dest_path, PATH_MAX);
+			/* make a copy of the file in the virtual hierarchy */
 			dest_path++;
 			retval = vufs_copyfile(vufs, dest_path, MAXSIZE);
 
@@ -787,18 +783,18 @@ int vu_vufs_fcntl(int fd, int cmd, ...) {
 			break;
 
 		case F_GETOWN_EX:
-		case F_SETOWN_EX: ;
+		case F_SETOWN_EX:
 			retval = fcntl(fd, cmd, va_arg(ap, struct f_owner_ex*));
 			break;
 
 		case F_GET_RW_HINT:
 		case F_SET_RW_HINT:
 		case F_GET_FILE_RW_HINT:
-		case F_SET_FILE_RW_HINT: ;
+		case F_SET_FILE_RW_HINT:
 			retval = fcntl(fd, cmd, va_arg(ap, uint64_t *));
 			break;
 
-		default: ;
+		default:
 			retval = fcntl(fd, cmd, va_arg(ap, int));
 			break;
 	}

--- a/vufuse/vufuse.c
+++ b/vufuse/vufuse.c
@@ -35,9 +35,7 @@ VU_PROTOTYPES(vufuse)
 
 	struct vu_module_t vu_module = {
 		.name = "vufuse",
-		.description = "vu virtual file systems (user level FUSE)",
-		.mod_nr_vsyscalls = 0,
-		.vsyscalls = NULL
+		.description = "vu virtual file systems (user level FUSE)"
 	};
 
 /* values for INUSE and thread synchro */

--- a/vumisc/vumisc.c
+++ b/vumisc/vumisc.c
@@ -68,9 +68,7 @@ VU_PROTOTYPES(vumisc)
 
 	struct vu_module_t vu_module = {
 		.name = "vumisc",
-		.description = "system call virtualization using info file system",
-		.mod_nr_vsyscalls = 0,
-		.vsyscalls = NULL
+		.description = "system call virtualization using info file system"
 	};
 
 struct vumisc_t {


### PR DESCRIPTION
Fcntl and flock are virtualized through VUFS using a supporting file for each lock request instead of the original one.

Note that this  implementation **needs testing**:

- check that all cases are correctly handled
- check that the SC behave correctly in case of multi-threaded programs
- **close** the newly created files when the actual one is (it shouldn't be possible doing it before)